### PR TITLE
Changed Eigen GIT_TAG to 3.4.1, seems to fix the compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   Eigen3
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG master
+  GIT_TAG 3.4.1
 )
 FetchContent_MakeAvailable(Eigen3)
 


### PR DESCRIPTION
The GIT_TAG master for Eigen appears to occasionally cause issues in the CMAKE -S . -B build step. I have changed it to 3.4.1 and it appears to work.